### PR TITLE
feat: permissions data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-framework v1.2.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/hashicorp/terraform-plugin-docs v0.14.1 h1:MikFi59KxrP/ewrZoaowrB9he5
 github.com/hashicorp/terraform-plugin-docs v0.14.1/go.mod h1:k2NW8+t113jAus6bb5tQYQgEAX/KueE/u8X2Z45V1GM=
 github.com/hashicorp/terraform-plugin-framework v1.2.0 h1:MZjFFfULnFq8fh04FqrKPcJ/nGpHOvX4buIygT3MSNY=
 github.com/hashicorp/terraform-plugin-framework v1.2.0/go.mod h1:nToI62JylqXDq84weLJ/U3umUsBhZAaTmU0HXIVUOcw=
+github.com/hashicorp/terraform-plugin-framework-validators v0.10.0 h1:4L0tmy/8esP6OcvocVymw52lY0HyQ5OxB7VNl7k4bS0=
+github.com/hashicorp/terraform-plugin-framework-validators v0.10.0/go.mod h1:qdQJCdimB9JeX2YwOpItEu+IrfoJjWQ5PhLpAOMDQAE=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
 github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4Nz1pepLXj95oyy0=

--- a/internal/cloudapi/getPermissions.go
+++ b/internal/cloudapi/getPermissions.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type (
+	PermissionsRequest struct {
+		Platform string `json:"platform"`
+		Type     string `json:"type"`
+	}
+
+	DocumentPermissions struct {
+		Data PermissionsObject `json:"data"`
+	}
+
+	PermissionsAttributes struct {
+		Data string `json:"data"`
+	}
+
+	PermissionsObject struct {
+		Type       string                 `json:"type"`
+		Attributes *PermissionsAttributes `json:"attributes,omitempty"`
+	}
+)
+
+func (c *Client) GetPermissions(ctx context.Context, orgID string, request *PermissionsRequest) (env *PermissionsObject, e error) {
+	url := fmt.Sprintf("%s/rest/orgs/%s/cloud/permissions", c.url, orgID)
+	version := "2022-04-13~experimental"
+	requestJson := map[string]interface{}{
+		"data": map[string]interface{}{
+			"attributes": request,
+			"type":       "permission",
+		},
+	}
+
+	requestBytes, err := json.Marshal(requestJson)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(requestBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	query := req.URL.Query()
+	query.Set("version", version)
+	req.URL.RawQuery = query.Encode()
+
+	req.Header.Set("Content-Type", "application/vnd.api+json")
+	req.Header.Set("Authorization", c.authorization)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil && e == nil {
+			e = err
+		}
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid status code: %v", res.StatusCode)
+	}
+
+	var result DocumentPermissions
+
+	body, _ := io.ReadAll(res.Body)
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return &result.Data, nil
+}

--- a/internal/provider/permissions_resource.go
+++ b/internal/provider/permissions_resource.go
@@ -1,0 +1,134 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/snyk-terraform-assets/terraform-provider-snyk/internal/cloudapi"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &PermissionsResource{}
+
+func NewPermissionsResource() resource.Resource {
+	return &PermissionsResource{}
+}
+
+// PermissionsResource defines the data source implementation.
+type PermissionsResource struct {
+	client cloudapi.Client
+}
+
+// PermissionsResourceModel describes the data source data model.
+type PermissionsResourceModel struct {
+	OrganizationId types.String `tfsdk:"organization_id"`
+	Platform       types.String `tfsdk:"platform"`
+	Type           types.String `tfsdk:"type"`
+	Data           types.String `tfsdk:"data"`
+}
+
+func (d *PermissionsResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_permissions"
+}
+
+func (d *PermissionsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		// This description is used by the documentation generator and the language server.
+		MarkdownDescription: "Permissions data source",
+
+		Attributes: map[string]schema.Attribute{
+			"organization_id": schema.StringAttribute{
+				MarkdownDescription: "Snyk organization ID",
+				Required:            true,
+			},
+			"platform": schema.StringAttribute{
+				MarkdownDescription: "Platform, should be `aws`",
+				Required:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("aws")},
+			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "Type, should be `cf`",
+				Required:            true,
+				Validators:          []validator.String{stringvalidator.OneOf("cf")},
+			},
+			"data": schema.StringAttribute{
+				MarkdownDescription: "Permission data, e.g. template body to create an AWS CloudFormation Stack",
+				Computed:            true,
+				Optional:            true,
+			},
+		},
+	}
+}
+
+func (d *PermissionsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*cloudapi.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *http.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = *client
+}
+
+func (d *PermissionsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data PermissionsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := d.recomputeData(ctx, &data); err != nil {
+		resp.Diagnostics.AddError("client error", fmt.Sprintf("%s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PermissionsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+}
+
+func (d *PermissionsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data PermissionsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if err := d.recomputeData(ctx, &data); err != nil {
+		resp.Diagnostics.AddError("client error", fmt.Sprintf("%s", err))
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PermissionsResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func (d *PermissionsResource) recomputeData(ctx context.Context, permissions *PermissionsResourceModel) error {
+	organizationId := permissions.OrganizationId.ValueString()
+	platform := permissions.Platform.ValueString()
+	type_ := permissions.Type.ValueString()
+	result, err := d.client.GetPermissions(ctx, organizationId, &cloudapi.PermissionsRequest{
+		Platform: platform,
+		Type:     type_,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to get permissions: %w", err)
+	}
+	permissions.Data = types.StringValue(result.Attributes.Data)
+	return nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -88,11 +88,13 @@ func (p *SnykProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 func (p *SnykProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewEnvironmentResource,
+		NewPermissionsResource,
 	}
 }
 
 func (p *SnykProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+	}
 }
 
 func New(version string) func() provider.Provider {


### PR DESCRIPTION
This adds a `snyk_permissions` resource.  I first tried doing it as a data resource, but that doesn't quite work as the template we're returning is non-deterministic in the role name.

This makes it a lot easier to set up environments, since you don't need the manual steps of generating a template and getting the role ARN.

Example usage:

    resource "snyk_permissions" "aws_cf_permissions" {
      organization_id = var.snyk_org
      platform        = "aws"
      type            = "cf"
    }

    resource "aws_cloudformation_stack" "rolestack" {
      name          = "tf-snyk-dev-role"
      capabilities  = ["CAPABILITY_NAMED_IAM"]
      template_body = snyk_permissions.aws_cf_permissions.data
    }

    resource "snyk_environment" "example" {
      name            = "little_env_12345_lol"
      kind            = "aws"
      organization_id = var.snyk_org
      aws {
        role_arn = aws_cloudformation_stack.rolestack.outputs.SnykCloudRoleArn
      }
    }