### PR TITLE
add TEST_SNYK_ROLE_ID env var

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,4 +95,5 @@ jobs:
           TEST_SNYK_TOKEN: ${{ secrets.TEST_SNYK_TOKEN }}
           TEST_SNYK_ORG_ID: ${{ secrets.TEST_SNYK_ORG_ID }}
           TEST_SNYK_GROUP_ID: ${{ secrets.TEST_SNYK_GROUP_ID }}
+          TEST_SNYK_ROLE_ID: ${{ secrets.TEST_SNYK_ROLE_ID }}
           TEST_AWS_ARN: ${{ secrets.TEST_AWS_ARN }}


### PR DESCRIPTION
This has already been configured in the settings but needs to be passed to `make testacc` so we don't skip the test